### PR TITLE
Set style attribute instead of fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,9 @@ easier.
   <android-icon decorative />
   ```
 
-- `fillColor` - This property allows you to set the fill colour of an icon via
-  JS instead of requiring CSS changes. Note that any CSS values, such as
-  `fill: currentColor;` provided by the optional CSS file, may override colours
-  set with this prop.
+- `fillColor` - This property allows you to set the fill colour of an icon. it
+   will set an inline style on the svg element that will override any other
+   styles.
 
   Example:
 

--- a/template.mst
+++ b/template.mst
@@ -5,7 +5,7 @@
         class="material-design-icon <%title%>-icon"
         role="img"
         @click="$emit('click', $event)">
-    <svg :fill="fillColor"
+    <svg :style="`fill: ${fillColor}`"
          class="material-design-icon__svg"
          :width="size"
          :height="size"


### PR DESCRIPTION
Set the fillColor in the style attribute instead of the fill attribute. This makes the property useful when using the provided CSS file.