### PR TITLE
Test: click listener should be called

### DIFF
--- a/__tests__/icon.js
+++ b/__tests__/icon.js
@@ -49,4 +49,23 @@ describe('Icon', () => {
   it('renders an icon', () => {
     expect(icon).toMatchSnapshot();
   });
+
+  it('listens to a click event', () => {
+    const clickListener = jest.fn()
+    const iconWithEvent = mount({
+      name: 'IconWithEvent',
+      components: { AndroidIcon },
+      template: `
+        <AndroidIcon
+          @click="clickListener"
+        />
+      `,
+      methods: {
+        clickListener,
+      },
+    })
+
+    iconWithEvent.trigger('click')
+    expect(clickListener).toBeCalled()
+  });
 });


### PR DESCRIPTION
The unit test seems to fail when testing that a click listener is called