### PR TITLE
fix: apply listeners correctly in functional component

### DIFF
--- a/__tests__/icon.js
+++ b/__tests__/icon.js
@@ -49,4 +49,23 @@ describe('Icon', () => {
   it('renders an icon', () => {
     expect(icon).toMatchSnapshot();
   });
+
+  it('listens to a click event', () => {
+    const clickListener = jest.fn()
+    const iconWithEvent = mount({
+      name: 'IconWithEvent',
+      components: { AndroidIcon },
+      template: `
+        <AndroidIcon
+          @click="clickListener"
+        />
+      `,
+      methods: {
+        clickListener,
+      },
+    })
+
+    iconWithEvent.trigger('click')
+    expect(clickListener).not.toBeCalled()
+  });
 });

--- a/__tests__/icon.js
+++ b/__tests__/icon.js
@@ -66,6 +66,6 @@ describe('Icon', () => {
     })
 
     iconWithEvent.trigger('click')
-    expect(clickListener).not.toBeCalled()
+    expect(clickListener).toBeCalled()
   });
 });

--- a/template.mst
+++ b/template.mst
@@ -5,7 +5,7 @@
         :class="[data.class, data.staticClass]"
         class="material-design-icon <%title%>-icon"
         role="img"
-        @click="listeners.click ? listeners.click : () => true">
+        v-on="listeners">
     <svg :fill="props.fillColor"
          class="material-design-icon__svg"
          :width="props.size"


### PR DESCRIPTION
Adds a failing test to demonstrate that the click handler was broken, then merge the fix