### PR TITLE
feat: New icons (& dont auto merge dep upgrades)

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -13,7 +13,3 @@ update_configs:
       prefix: "feat"
       prefix_development: "chore"
       include_scope: true
-    automerged_updates:
-      - match:
-          dependency_type: "development"
-          update_type: "all"


### PR DESCRIPTION
I'd previously attempted to automate the release of this library, but forgot that `@mdi/js` was a dev dep (its required for building, but not production)

Changing the dependabot config so that we don't automerge; this will give me the ability to manually alter the commit message for MDI updates to trigger a new release

Marking this patch as a "feat" so that new icons / deps are released alongside it