### PR TITLE
Update template.mst

### DIFF
--- a/template.mst
+++ b/template.mst
@@ -1,8 +1,9 @@
 {{=<% %>=}}
 <template functional>
-  <span :aria-hidden="props.decorative"
+  <div :aria-hidden="props.decorative"
         :aria-label="props.title"
         :class="[data.class, data.staticClass]"
+        :style="{height: props.size + 'px'}"
         class="material-design-icon <%title%>-icon"
         role="img"
         v-bind="data.attrs"
@@ -16,7 +17,7 @@
         <title>{{ props.title }}</title>
       </path>
     </svg>
-  </span>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Fixed vertical alignment of icon, container `<span>` it can't be adjusted with height attribute because it's inline element.
Now the height of the container matches with the height of the icon because it uses the same `prop.size` to fit the right size without major CSS adjustments.

#### Before:
![chrome_ok2EFVfyyN](https://user-images.githubusercontent.com/44122984/94171206-48019e00-fe91-11ea-9bc1-239677da25fb.png)

#### Now:
![chrome_XQjG8fGGiq](https://user-images.githubusercontent.com/44122984/94171227-4e901580-fe91-11ea-8a65-a68a830e2916.png)
