### PR TITLE
Remove title when purely decorative.

### DIFF
--- a/template.mst
+++ b/template.mst
@@ -13,7 +13,7 @@
          :height="props.size"
          viewBox="0 0 24 24">
       <path d="<%{svgPathData}%>">
-        <title>{{ props.title }}</title>
+        <title v-if="!props.decorative">{{ props.title }}</title>
       </path>
     </svg>
   </span>


### PR DESCRIPTION
Addresses issue #115 with the trivial suggestion (remove title element when decorative flag is set) 