### PR TITLE
feat: Require a title or decorative prop to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ easier.
 ## Props
 
 - `title` - This changes the hover tooltip as well as the title shown to screen
-  readers. By default, those values are a "human readable" conversion of the
-  icon names; for example `chevron-down-icon` becomes "Chevron down icon".
+  readers. For accessibility purposes, a title is required unless the 
+  `decorative` prop is set to `true`.
 
   Example:
 

--- a/build.js
+++ b/build.js
@@ -12,11 +12,10 @@ const templateFile = path.resolve(__dirname, 'template.mst');
 const template = fs.readFileSync(templateFile, { encoding: 'utf8' });
 const process = require('process');
 
-function renderAndWrite({ name, title, readableName, svgPathData }) {
+function renderAndWrite({ name, title, svgPathData }) {
   const component = mustache.render(template, {
     name,
     title,
-    readableName,
     svgPathData,
   });
   const filename = `${name}.vue`;
@@ -33,14 +32,9 @@ function getTemplateData(id) {
   // "android", for example
   const title = splitID.join('-').toLowerCase();
 
-  // Transforms the icon ID to a human readable form for default titles.
-  // For example, "mdiAndroidStudio" becomes "Android Studio"
-  const readableName = splitID.join(' ');
-
   return {
     name,
     title,
-    readableName,
     svgPathData: icons[id],
   };
 }

--- a/template.mst
+++ b/template.mst
@@ -25,7 +25,6 @@ export default {
   props: {
     title: {
       type: String,
-      default: "<%readableName%> icon"
     },
     decorative: {
       type: Boolean,
@@ -38,6 +37,12 @@ export default {
     size: {
       type: Number,
       default: 24
+    }
+  },
+  methods :{
+    created() {
+      if (this.decorative) this.title = null;
+      if (!this.decorative && !this.title) throw new TypeError('Icons must have a title or be declared as decorative.', '<%name%>Icon.vue')
     }
   }
 }


### PR DESCRIPTION
Removes the automatic generation of a human readable title, instead requiring either a `title` or the `decorative` prop to be set. This enables automated accessibility testing (e.g. with aXe) without the auto-generated title providing a false positive.

This is important because the icon name (e.g. "Chevron Down") describes the icon and not the function it represents (e.g. "Expand menu options").