### PR TITLE
fix: Prevent double clicking in Vue 3

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -32,6 +32,7 @@ function renderTemplate(title: string, svgPathData: string, name: string) {
 <script>
 export default {
   name: "${name}Icon",
+  emits: ['click'],
   props: {
     title: {
       type: String,


### PR DESCRIPTION
In Vue 3, click events fall through meaning each event is fired twice when adding @click prop to the component. Adding emits: ['click'] tells the component to expect an external click event, therefore preventing the double event.

Co-Authored-By: 1VinceP <vpalmergraphics@gmail.com>