### PR TITLE
fix: replace string to icons key type and resolve type error

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -9,6 +9,8 @@ import { existsSync } from 'fs';
 
 const dist = path.resolve(__dirname, 'dist');
 
+type IconsKey = keyof typeof icons;
+
 function renderTemplate(title: string, svgPathData: string, name: string) {
   return `<template>
   <span v-bind="$attrs"
@@ -50,7 +52,7 @@ export default {
 </script>`;
 }
 
-function getTemplateData(id: string) {
+function getTemplateData(id: IconsKey) {
   const splitID = id.split(/(?=[A-Z])/).slice(1);
 
   const name = splitID.join('');
@@ -67,7 +69,7 @@ function getTemplateData(id: string) {
 }
 
 async function build() {
-  const iconIDs = Object.keys(icons);
+  const iconIDs = Object.keys(icons) as IconsKey[];
 
   if (!existsSync(dist)) {
     await mkdir(dist);


### PR DESCRIPTION
Hi👋
I found a type error in `build.ts`, so I resolved this.


![ScreenCapture 2022-09-22 2 42 02](https://user-images.githubusercontent.com/80559385/191574022-6dac1eaf-aed8-41c3-bcd0-059a903f1f0b.png)
