### PR TITLE
fix: Do not define aria-hidden when not hidden

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -12,7 +12,7 @@ const dist = path.resolve(__dirname, 'dist');
 function renderTemplate(title: string, svgPathData: string, name: string) {
   return `<template>
   <span v-bind="$attrs"
-        :aria-hidden="!title"
+        :aria-hidden="title ? null : true"
         :aria-label="title"
         class="material-design-icon ${title}-icon"
         role="img"


### PR DESCRIPTION
See https://github.com/robcresswell/vue-material-design-icons/issues/294

Setting  the `v-bind` to `null` should cause the attribute to be completely omitted.