### PR TITLE
fix: `aria-hidden` expects a string as value

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -12,7 +12,7 @@ const dist = path.resolve(__dirname, 'dist');
 function renderTemplate(title: string, svgPathData: string, name: string) {
   return `<template>
   <span v-bind="$attrs"
-        :aria-hidden="title ? null : true"
+        :aria-hidden="title ? null : 'true'"
         :aria-label="title"
         class="material-design-icon ${title}-icon"
         role="img"


### PR DESCRIPTION
`aria-hidden` expects a value of `'true'` or `'false'` as it is not a boolean property.

Because currently it results in `<span aria-hidden ...` instead of expected `<span aria-hidden="true" ...`.